### PR TITLE
Updated markdown fonts

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -2,6 +2,10 @@ body, .markdown-body, .intgrs-page .main-content, .blog-content, .migration-wrap
   font-family: Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
 }
 
+.markdown-body {
+    font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
 body {
   font-size: 13px !important;
   line-height: 1.4 !important;


### PR DESCRIPTION
I had a github markdown page open prior to the switch, so I copied the .markdown-body code directly from inspection of that page.